### PR TITLE
Parameterization of unit and measurement, handle non-unique metric names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ eggs
 env
 .idea
 data
+venv
+.vscode

--- a/metric_aggregates/from_individual_message_export.py
+++ b/metric_aggregates/from_individual_message_export.py
@@ -99,16 +99,17 @@ class AggregatesFromIndividualMessageExport(object):
         Gets metric data from metric export endpoint for metric_name, campaigns list. Performs a \
         single request per campaign in campaigns list.
         """
-        metric_id = utils.get_metric_id(metric_name, self.client)
+        metric_ids = utils.get_metric_id(metric_name, self.client)
         metric_data = []
-        for message_id in tqdm(message_ids):
-            message = '[["$message","=","{}"]]'.format(message_id)
-            response = self.client.metric_export(metric_id,
-                                                 start_date=start_date,
-                                                 end_date=end_date,
-                                                 where=message,
-                                                 unit="day")
-            metric_data.append(response)
+        for metric_id in metric_ids:
+            for message_id in tqdm(message_ids):
+                message = '[["$message","=","{}"]]'.format(message_id)
+                response = self.client.metric_export(metric_id,
+                                                    start_date=start_date,
+                                                    end_date=end_date,
+                                                    where=message,
+                                                    unit="day")
+                metric_data.extend(response)
         return metric_data
 
     def get_metric_export_for_all_messages(self, metric_id, start_date, end_date):

--- a/metric_aggregates/from_individual_message_export.py
+++ b/metric_aggregates/from_individual_message_export.py
@@ -94,7 +94,7 @@ class AggregatesFromIndividualMessageExport(object):
 
         return all_message_ids
 
-    def get_metric_data_from_export_for_message_ids(self, metric_name, message_ids, start_date, end_date, unit="day"):
+    def get_metric_data_from_export_for_message_ids(self, metric_name, message_ids, start_date, end_date, unit, measurement):
         """
         Gets metric data from metric export endpoint for metric_name, campaigns list. Performs a \
         single request per campaign in campaigns list.
@@ -108,7 +108,8 @@ class AggregatesFromIndividualMessageExport(object):
                                                     start_date=start_date,
                                                     end_date=end_date,
                                                     where=message,
-                                                    unit=unit)
+                                                    unit=unit,
+                                                    measurement=measurement)
                 metric_data.extend(response)
         return metric_data
 
@@ -123,7 +124,7 @@ class AggregatesFromIndividualMessageExport(object):
                                          by="$message",
                                          count=10000)
 
-    def main(self, metric_name, start_date, end_date):
+    def main(self, metric_name, start_date, end_date, unit="day", measurement="count"):
         """
         Gets metric export data for specific metric name by first getting all message IDs
         for campaigns & flows, then looping over message_id list and passing each message ID
@@ -135,9 +136,11 @@ class AggregatesFromIndividualMessageExport(object):
         flow_ids = self.get_flow_message_ids()
         print("{} Flow message IDs found for account.".format(len(flow_ids)))
         message_ids.extend(flow_ids)
-        print("Getting metric export data for {metric_name} from {start_date} to {end_date} "
-              "for {message_count} messages (this may take a little while)...".format(metric_name=metric_name,
+        print("Getting metric export data for {measurement} of {metric_name} from {start_date} to {end_date} by {unit} "
+              "for {message_count} messages (this may take a little while)...".format(measurement=measurement,
+                                                                                      metric_name=metric_name,
                                                                                       message_count=len(message_ids),
                                                                                       start_date=start_date,
-                                                                                      end_date=end_date))
-        return self.get_metric_data_from_export_for_message_ids(metric_name, message_ids, start_date, end_date)
+                                                                                      end_date=end_date,
+                                                                                      unit=unit))
+        return self.get_metric_data_from_export_for_message_ids(metric_name, message_ids, start_date, end_date, unit, measurement)

--- a/metric_aggregates/from_individual_message_export.py
+++ b/metric_aggregates/from_individual_message_export.py
@@ -94,7 +94,7 @@ class AggregatesFromIndividualMessageExport(object):
 
         return all_message_ids
 
-    def get_metric_data_from_export_for_message_ids(self, metric_name, message_ids, start_date, end_date):
+    def get_metric_data_from_export_for_message_ids(self, metric_name, message_ids, start_date, end_date, unit="day"):
         """
         Gets metric data from metric export endpoint for metric_name, campaigns list. Performs a \
         single request per campaign in campaigns list.
@@ -108,7 +108,7 @@ class AggregatesFromIndividualMessageExport(object):
                                                     start_date=start_date,
                                                     end_date=end_date,
                                                     where=message,
-                                                    unit="day")
+                                                    unit=unit)
                 metric_data.extend(response)
         return metric_data
 

--- a/metric_aggregates/utils.py
+++ b/metric_aggregates/utils.py
@@ -2,10 +2,10 @@ def get_metric_id(metric_name, client):
     """
     Gets metric ID from metric name.
     """
-    event_id = None
+    event_id = []
     response = client.metrics()
     metrics = response["data"]
     for m in metrics:
         if m["name"] == metric_name:
-            event_id = m["id"]
+            event_id.extend(m["id"])
     return event_id


### PR DESCRIPTION
- `utils.get_metric_id()` now returns a list instead of a string, to handle cases where more than one metric has the same name
- `from_individual_message_export.AggregatesFromIndividualMessageExport.get_metric_data_from_export_for_message_ids()` now includes an extra for-loop to handle the list coming from `utils.get_metric_id()`.
- `unit` no longer hard-coded as "day", allowing other units to be specified when calling `AggregatesFromIndividualMessageExport.main()`.
- Added  `measurement` param to allow the extraction of things other than the default of "count".